### PR TITLE
Fixed navigation to not be seperate <nav> blocks

### DIFF
--- a/src/app/components/about/about.component.html
+++ b/src/app/components/about/about.component.html
@@ -1,3 +1,5 @@
-<p>
-  about works!
-</p>
+<div class="main">
+  <p>
+    about works!
+  </p>
+</div>

--- a/src/app/components/about/about.component.sass
+++ b/src/app/components/about/about.component.sass
@@ -1,0 +1,2 @@
+.main
+    margin-left: 8%

--- a/src/app/components/navigation/navigation.component.html
+++ b/src/app/components/navigation/navigation.component.html
@@ -1,4 +1,6 @@
 <div class="sidenav">
-    <nav [routerLink]="['']" routerLinkActive="router-link-active">Home</nav>
-    <nav [routerLink]="['/about']" routerLinkActive="router-link-active">About</nav>
+    <nav>
+        <a [routerLink]="['']" routerLinkActive="router-link-active">Home</a>
+        <a [routerLink]="['/about']">About</a>
+    </nav>
 </div>

--- a/src/app/components/navigation/navigation.component.sass
+++ b/src/app/components/navigation/navigation.component.sass
@@ -10,7 +10,7 @@
     padding-top: 60px
     transition: 0.5s
 
-.sidenav nav
+.sidenav nav a
     padding: 8px 8px 8px 32px
     text-decoration: none
     font-size: 25px
@@ -18,7 +18,7 @@
     display: block
     transition: 0.3s
 
-.sidenav nav:hover
+.sidenav nav a:hover
     color: #f1f1f1
 
 @media screen and (max-height: 450px)


### PR DESCRIPTION
Correct the use of `<nav>` to have `<a>` in one nav block.